### PR TITLE
[PT-905] bugfix/redirect from uri to version

### DIFF
--- a/easydita-knowledge-portal/page.php
+++ b/easydita-knowledge-portal/page.php
@@ -40,19 +40,17 @@ get_template_part("template-parts/breadcrumbs");
 
 		  		if (function_exists(set_post_views)) { set_post_views(get_the_ID()); }
 				
-				if ($page_type == 'content') {
-					if (wp_get_post_parent_id( get_the_ID() ) == 0) {
-						get_template_part( 'template-parts/content', 'user-guide-home' );
-					} else {
-						get_template_part( 'template-parts/content', 'user-guide-content' );
-					}
-				} else if ($page_type == 'faq') {
+				if ($page_type == 'faq') {
 					get_template_part( 'template-parts/content', 'faq');
 				} else if ($page_type == 'tutorial') {
 					get_template_part( 'template-parts/content', 'tutorial' );
-				} else if (!get_post_meta(easydita_knowledge_portal_get_root_map_id(),'page_type')) {
+				} else if ($page_type == 'content' || !get_post_meta(easydita_knowledge_portal_get_root_map_id(),'page_type')) {
 					if (wp_get_post_parent_id( get_the_ID() ) == 0) {
-						get_template_part( 'template-parts/content', 'user-guide-home' );
+						if (easydita_knowledge_portal_is_versioning_enabled()) {
+							header('Location: /?version='.get_the_ID());
+						} else {
+							get_template_part( 'template-parts/content', 'user-guide-home' );
+						}
 					} else {
 						get_template_part( 'template-parts/content', 'user-guide-content' );
 					}


### PR DESCRIPTION
Updated the page redirects so that if a user tries to go directly to a root page (with parent = 0) via the URL, it will redirect to the home page with that version selected.

For example, on demo-docs.easydita.com, if you type into the address bar:
> http://demo-docs.easydita.com/jorsek-testing/

Now, it will redirect you to
> http://demo-docs.easydita.com/?version=20757

(The home page with "Jorsek Testing" selected as the version.)